### PR TITLE
Use X4 test set in train_swinir_sr_realworld_x4_psnr.json

### DIFF
--- a/options/swinir/train_swinir_sr_realworld_x4_psnr.json
+++ b/options/swinir/train_swinir_sr_realworld_x4_psnr.json
@@ -34,7 +34,7 @@
       "name": "test_dataset"            // just name
       , "dataset_type": "sr"         // "dncnn" | "dnpatch" | "fdncnn" | "ffdnet" | "sr" | "srmd" | "dpsr" | "plain" | "plainpatch" | "jpeg"
       , "dataroot_H": "testsets/Set5/HR"  // path of H testing dataset
-      , "dataroot_L": "testsets/Set5/LR_bicubic/X2"              // path of L testing dataset
+      , "dataroot_L": "testsets/Set5/LR_bicubic/X4"              // path of L testing dataset
 
     }
   }


### PR DESCRIPTION
Changed the test set to use testsets/Set5/LR_bicubic/X4. X2 was previously used which gave the error "Input Images must have the same dimension."