### PR TITLE
fix bug in utils_blindsr.py

### DIFF
--- a/utils/utils_blindsr.py
+++ b/utils/utils_blindsr.py
@@ -447,7 +447,7 @@ def degradation_bsrgan(img, sf=4, lq_patchsize=72, isp_model=None):
     sf_ori = sf
 
     h1, w1 = img.shape[:2]
-    img = img.copy()[:w1 - w1 % sf, :h1 - h1 % sf, ...]  # mod crop
+    img = img.copy()[:h1 - h1 % sf, :w1 - w1 % sf, ...]  # mod crop
     h, w = img.shape[:2]
 
     if h < lq_patchsize*sf or w < lq_patchsize*sf:
@@ -538,7 +538,7 @@ def degradation_bsrgan_plus(img, sf=4, shuffle_prob=0.5, use_sharp=False, lq_pat
     """
 
     h1, w1 = img.shape[:2]
-    img = img.copy()[:w1 - w1 % sf, :h1 - h1 % sf, ...]  # mod crop
+    img = img.copy()[:h1 - h1 % sf, :w1 - w1 % sf, ...]  # mod crop
     h, w = img.shape[:2]
 
     if h < lq_patchsize*sf or w < lq_patchsize*sf:


### PR DESCRIPTION
# Summary
In the mod crop operation, width and height are not being applied to the correct dimensions, leading to an inability to fully utilize all content in the training data.